### PR TITLE
Fix Ubuntu logo SVG rendering issue

### DIFF
--- a/images/illustrations/ubuntu-logo.svg
+++ b/images/illustrations/ubuntu-logo.svg
@@ -1,1 +1,34 @@
-File not found: /v1/AUTH_mw/wikipedia-commons-local-public.9e/9/9e/Ubuntu_logo_copyleft_1.svg
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <title>Ubuntu Logo</title>
+  <defs>
+    <style>
+      .ubuntu-orange { fill: #E95420; }
+      .ubuntu-white { fill: #FFFFFF; }
+    </style>
+  </defs>
+
+  <!-- Main circle background -->
+  <circle cx="100" cy="100" r="95" class="ubuntu-orange"/>
+
+  <!-- Three circles of friends (simplified Ubuntu logo representation) -->
+  <!-- Top circle -->
+  <circle cx="100" cy="30" r="15" class="ubuntu-white"/>
+  <circle cx="100" cy="30" r="8" class="ubuntu-orange"/>
+
+  <!-- Bottom left circle -->
+  <circle cx="50" cy="140" r="15" class="ubuntu-white"/>
+  <circle cx="50" cy="140" r="8" class="ubuntu-orange"/>
+
+  <!-- Bottom right circle -->
+  <circle cx="150" cy="140" r="15" class="ubuntu-white"/>
+  <circle cx="150" cy="140" r="8" class="ubuntu-orange"/>
+
+  <!-- Connecting arcs (simplified) -->
+  <path d="M 100 45 Q 75 85 55 125" stroke="#FFFFFF" stroke-width="6" fill="none" stroke-linecap="round"/>
+  <path d="M 100 45 Q 125 85 145 125" stroke="#FFFFFF" stroke-width="6" fill="none" stroke-linecap="round"/>
+  <path d="M 65 140 L 135 140" stroke="#FFFFFF" stroke-width="6" stroke-linecap="round"/>
+
+  <!-- Center text "ubuntu" -->
+  <text x="100" y="105" font-family="Ubuntu, sans-serif" font-size="24" text-anchor="middle" class="ubuntu-white" font-weight="300">ubuntu</text>
+</svg>


### PR DESCRIPTION
Fixes #8

The ubuntu-logo.svg file contained an error message instead of valid SVG content. Replaced it with a properly formatted SVG that includes:
- Valid XML structure with proper xmlns declaration
- Ubuntu's official orange color (#E95420)
- Simplified representation of the Ubuntu 'Circle of Friends' logo
- Proper viewBox for scalability

Generated with [Claude Code](https://claude.ai/code)