### PR TITLE
Fix Settings navigation: About is now under Settings > System > About

### DIFF
--- a/chapters/01-what-is-a-computer.md
+++ b/chapters/01-what-is-a-computer.md
@@ -51,8 +51,9 @@ Let's find out how fast YOUR CPU is:
 
 1. Click the Applications menu (the Ubuntu logo at the bottom-left)
 2. Type "Settings" and open it
-3. Click "About" on the left
-4. Look for "Processor" - that's your CPU!
+3. Click "System" on the left
+4. Click "About"
+5. Look for "Processor" - that's your CPU!
 
 Is it 2.0 GHz? 3.5 GHz? Whatever it is, that number means "billions of things per second." Pretty cool, right?
 
@@ -89,8 +90,9 @@ Let's see how much RAM (desk space) your computer has:
 
 1. Click Applications (the Ubuntu logo again)
 2. Type "Settings" and open it
-3. Click "About"
-4. Look for "Memory" - that's your RAM!
+3. Click "System" on the left
+4. Click "About"
+5. Look for "Memory" - that's your RAM!
 
 Most computers have between 4 GB and 16 GB. That's gigabytes, which means billions of bytes. A byte is basically enough memory to store one letter. So 4 GB? That's enough to store about 4 BILLION letters! Or... like a million pages of text. Or... okay, you get the idea. It's a lot!
 

--- a/chapters/02-meet-ubuntu.md
+++ b/chapters/02-meet-ubuntu.md
@@ -248,8 +248,8 @@ When you're done using your computer, click the power button 🔘 in the top-rig
 2. Practice minimizing 📦, maximizing 🔲, and arranging them (window Tetris! 🎮)
 3. Create a text file using Text Editor 📝 and save it in your Documents folder 💾
 4. **Settings Detective Time!** 🕵️ Open Settings and investigate:
-   - What's your CPU speed? (Settings > About > Processor 🧠)
-   - How much RAM do you have? (Settings > About > Memory 🗂️)
+   - What's your CPU speed? (Settings > System > About > Processor 🧠)
+   - How much RAM do you have? (Settings > System > About > Memory 🗂️)
    - What's your computer's name? (You can even change it if you want! 🏷️)
 
 **Hard:** 🔴

--- a/chapters/06-customizing-ubuntu.md
+++ b/chapters/06-customizing-ubuntu.md
@@ -219,7 +219,7 @@ Got wireless headphones, a mouse, or a keyboard? Let's connect them!
 
 Your computer has a name! Let's see it and change it:
 
-1. Settings > About
+1. Settings > System > About
 2. Look for "Device Name"
 3. Click on it to change it
 


### PR DESCRIPTION
Updated instructions in chapters 1, 2, and 6 to reflect the current Ubuntu Settings UI where "About" is nested under the "System" section in the left sidebar, not directly accessible from Settings root.

Fixes #14

Generated with [Claude Code](https://claude.ai/code)